### PR TITLE
Fixing some bugs in downloaded tab

### DIFF
--- a/GCManager/ModManager.cs
+++ b/GCManager/ModManager.cs
@@ -111,9 +111,8 @@ namespace GCManager
                 mod.authorLink = new Uri("https://thunderstore.io/package/" + mod.author);
                 mod.description = manifest.description;
                 mod.version = manifest.version_number;
-
-                if (mod.dependencies != null)
-                    mod.dependencies = manifest.dependencies.ToArray();
+                mod.imageLink = new Uri(Path.Combine(dir, "icon.png"));
+                mod.dependencies = manifest.dependencies.ToArray();
 
                 if (manifest.website_url.Length > 0)
                     mod.modLink = new Uri(manifest.website_url);


### PR DESCRIPTION
Fixes icons not showing in downloaded tab
Fixes bug where the client would crash upon trying to install from downloaded tab:
 - "if" statement broke the "foreach (string dependency in mod.dependencies)" statement in the 
    InstallMod function due to sending a null property. 
 